### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,9 +13,9 @@ ClosedCube_TCA9546A	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ##################################################################
 
-begin KEYWORD2
-selectChannel KEYWORD2
-nextChannel KEYWORD2
-getChannel KEYWORD2
+begin	KEYWORD2
+selectChannel	KEYWORD2
+nextChannel	KEYWORD2
+getChannel	KEYWORD2
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords